### PR TITLE
fix non compliant Python3 print statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 libbcm2835
 ==========
+Fork of mubeta06/py-libbcm2835 to address Python 3 issues
 
 Python bindings to the C library for Broadcom BCM 2835 as used in Raspberry Pi. (http://www.airspayce.com/mikem/bcm2835/)
 
 These bindings require the library be built as a shared library object. To do this manually simply gcc -shared -o libbcm2835.so -fPIC bcm2835.c and copy library to /usr/local/lib.
+
+Installation
+------------
+1. Clone from git or download zip file and extract
+
+2. In root of download directory type
+
+  sudo python3 setup.py install
+
+NB, you can also use Python 2, simply type
+
+  sudo python setup.py install
+
+3. You can now use the library in your code like so:
+
+import libbcm2835._bcm2835 as soc
+
+print(soc.BCM2835_I2C_REASON_OK)

--- a/libbcm2835/spi.py
+++ b/libbcm2835/spi.py
@@ -38,7 +38,7 @@ def main():
     # Send a byte to the slave and simultaneously read a byte back from the slave
     # If you tie MISO to MOSI, you should read back what was sent
     data = bcm2835_spi_transfer(0x23);
-    print "Read from SPI: %02X\n" % data
+    print("Read from SPI: %02X" % data)
 
     bcm2835_spi_end()
     bcm2835_close()


### PR DESCRIPTION
spi.py print statement won't work in Python 3, so just a small fix
tested using
python3 setup.py install
and
python setup.py install

output is:
pi@raspberrypi ~/libbcm2836-py3 $ sudo python3 setup.py install
running install
running build
running build_py
creating build
creating build/lib
creating build/lib/libbcm2835
copying ./libbcm2835/**init**.py -> build/lib/libbcm2835
copying ./libbcm2835/_bcm2835.py -> build/lib/libbcm2835
copying ./libbcm2835/spi.py -> build/lib/libbcm2835
running install_lib
copying build/lib/libbcm2835/__init__.py -> /usr/local/lib/python3.2/dist-packages/libbcm2835
copying build/lib/libbcm2835/_bcm2835.py -> /usr/local/lib/python3.2/dist-packages/libbcm2835
copying build/lib/libbcm2835/spi.py -> /usr/local/lib/python3.2/dist-packages/libbcm2835
byte-compiling /usr/local/lib/python3.2/dist-packages/libbcm2835/__init__.py to **init**.cpython-32.pyc
byte-compiling /usr/local/lib/python3.2/dist-packages/libbcm2835/_bcm2835.py to _bcm2835.cpython-32.pyc
byte-compiling /usr/local/lib/python3.2/dist-packages/libbcm2835/spi.py to spi.cpython-32.pyc
running install_egg_info
Removing /usr/local/lib/python3.2/dist-packages/libbcm2835-1.0.egg-info
Writing /usr/local/lib/python3.2/dist-packages/libbcm2835-1.0.egg-info

pi@raspberrypi ~/libbcm2836-py3 $ sudo python setup.py install
running install
running build
running build_py
creating build/lib.linux-armv6l-2.7
creating build/lib.linux-armv6l-2.7/libbcm2835
copying ./libbcm2835/**init**.py -> build/lib.linux-armv6l-2.7/libbcm2835
copying ./libbcm2835/_bcm2835.py -> build/lib.linux-armv6l-2.7/libbcm2835
copying ./libbcm2835/spi.py -> build/lib.linux-armv6l-2.7/libbcm2835
running install_lib
creating /usr/local/lib/python2.7/dist-packages/libbcm2835
copying build/lib.linux-armv6l-2.7/libbcm2835/__init__.py -> /usr/local/lib/python2.7/dist-packages/libbcm2835
copying build/lib.linux-armv6l-2.7/libbcm2835/_bcm2835.py -> /usr/local/lib/python2.7/dist-packages/libbcm2835
copying build/lib.linux-armv6l-2.7/libbcm2835/spi.py -> /usr/local/lib/python2.7/dist-packages/libbcm2835
byte-compiling /usr/local/lib/python2.7/dist-packages/libbcm2835/__init__.py to **init**.pyc
byte-compiling /usr/local/lib/python2.7/dist-packages/libbcm2835/_bcm2835.py to _bcm2835.pyc
byte-compiling /usr/local/lib/python2.7/dist-packages/libbcm2835/spi.py to spi.pyc
running install_egg_info
Writing /usr/local/lib/python2.7/dist-packages/libbcm2835-1.0.egg-info
